### PR TITLE
Add type hints to defs.py and test_defs.py

### DIFF
--- a/defs.py
+++ b/defs.py
@@ -23,23 +23,23 @@ nlines = 19  # +1, so 20 in total since rr[1] is added by hand
 # definitions
 
 
-def find_separatrix(z, Bz):
+def find_separatrix(z: np.ndarray, Bz: np.ndarray) -> tuple[int, float]:
     """find the integration end near the axis where the magnetic field changes topologically,
     i.e, where B_z near the axis chnages sign"""
-    Bzline = Bz[1, :]  # 1 means one point in r above symmetry axis
+    Bzline: np.ndarray = Bz[1, :]  # 1 means one point in r above symmetry axis
 
-    end_index = np.where(Bzline > 0)[0]
+    end_index: np.ndarray = np.where(Bzline > 0)[0]
     if end_index.size == 0:  # catch empty array
-        zmax = z[1, -1]
+        zmax: float = z[1, -1]
         print(zmax)
         print(z)
         return nres, zmax
-    end_index = end_index[0]
-    zsep = z[1, end_index]
-    return end_index, zsep  # index and z coordinate, where B_z is positive
+    end_idx: int = end_index[0]
+    zsep: float = z[1, end_idx]
+    return end_idx, zsep  # index and z coordinate, where B_z is positive
 
 
-def add_lengths_to_df(df, norm=1):
+def add_lengths_to_df(df: "pd.DataFrame", norm: float = 1.0) -> "pd.DataFrame":
     """add the various measures to the dataframe df"""
     df.length = df.length / norm
     df["l_mr"] = df.length * np.sqrt(df.mr)
@@ -49,14 +49,22 @@ def add_lengths_to_df(df, norm=1):
     return df
 
 
-def parallelism(zz, rr, Binterp_z, Binterp_r, R, L, p=1):
+def parallelism(
+    zz: np.ndarray,
+    rr: np.ndarray,
+    Binterp_z: RegularGridInterpolator,
+    Binterp_r: RegularGridInterpolator,
+    R: float,
+    L: float,
+    p: float = 1.0,
+) -> float:
     """calculate average theta = arctan2(br / bz) within (0,0) and (p*L,p*R) at the nres positions"""
-    rp = rr[np.where(rr < p * R)]
-    zp = zz[np.where(zz < p * L)]
+    rp: np.ndarray = rr[np.where(rr < p * R)]
+    zp: np.ndarray = zz[np.where(zz < p * L)]
 
-    i = 0
-    br = 0
-    bz = 0
+    i: int = 0
+    br: float = 0.0
+    bz: float = 0.0
     for r in rp:
         for z in zp:
             br += Binterp_r([r, z])
@@ -66,14 +74,14 @@ def parallelism(zz, rr, Binterp_z, Binterp_r, R, L, p=1):
     return np.arctan2(br / i, bz / i)  # global angle theta (for that region)
 
 
-def active_volume(z, r, L, R):
+def active_volume(z: np.ndarray, r: np.ndarray, L: float, R: float) -> float:
     """active volume"""
     if z[-1] < 0.5 * L:
         # add last point to compare with the rectangle
         z = np.append(z, 0.5 * L)
         r = np.append(r, R)
 
-    active = np.trapz(np.power(r, 2), z)
+    active: float = np.trapz(np.power(r, 2), z)
 
     # relative active volume
     return active / (R**2 * 0.5 * L)
@@ -82,15 +90,24 @@ def active_volume(z, r, L, R):
 # basic plot
 
 
-def field_plot(z, rho, Bz, Br, R, L, dR, ax=None):
+def field_plot(
+    z: np.ndarray,
+    rho: np.ndarray,
+    Bz: np.ndarray,
+    Br: np.ndarray,
+    R: float,
+    L: float,
+    dR: float,
+    ax: mpl.axes.Axes = None,
+) -> None:
     """plot the magnetic field of the ring magnet"""
-    Bamp = np.linalg.norm(np.array([Bz, Br]), axis=0)
+    Bamp: np.ndarray = np.linalg.norm(np.array([Bz, Br]), axis=0)
 
     # plot
-    if ax == None:
+    if ax is None:
         fig, ax = plt.subplots(1, 1, figsize=(12, 7))
 
-    sp = ax.streamplot(
+    sp: mpl.streamplot.StreamplotSet = ax.streamplot(
         z,
         rho,
         Bz,
@@ -110,8 +127,8 @@ def field_plot(z, rho, Bz, Br, R, L, dR, ax=None):
         aspect=1,
     )
 
-    rect = Rectangle((0, R), 0.5 * L, dR)
-    pc = PatchCollection([rect], facecolor="green", alpha=0.5, edgecolor="k")
+    rect: Rectangle = Rectangle((0, R), 0.5 * L, dR)
+    pc: PatchCollection = PatchCollection([rect], facecolor="green", alpha=0.5, edgecolor="k")
     # Add collection to axes
     ax.add_collection(pc)
 
@@ -119,53 +136,80 @@ def field_plot(z, rho, Bz, Br, R, L, dR, ax=None):
 # field calculation
 @dataclass
 class Ring:
-    def __init__(self, R=20, L=50, dR=2, plt_on=False, ax=None):
+    R: float
+    L: float
+    dR: float
+    r0: list[float]
+    bri: RegularGridInterpolator
+    bzi: RegularGridInterpolator
+    pa: list[float]
+    z: np.ndarray
+    r: np.ndarray
+    zsep: float
+    ring: magpy.magnet.CylinderSegment
+
+    def __init__(
+        self, R: float = 20, L: float = 50, dR: float = 2, plt_on: bool = False, ax: mpl.axes.Axes = None
+    ):
         self.R = R
         self.L = L
         self.dR = dR
-        [r0, interp_r, interp_z, pa, zz, rr, zsep, magnet] = ring_calculation(R, L, dR, plt_on, ax)
-        self.r0 = r0
-        self.bri = interp_r
-        self.bzi = interp_z
-        self.pa = pa
-        self.z = zz
-        self.r = rr
-        self.zsep = zsep
-        self.ring = magnet
+        r0_val, interp_r_val, interp_z_val, pa_val, zz_val, rr_val, zsep_val, magnet_val = ring_calculation(
+            R, L, dR, plt_on, ax
+        )
+        self.r0 = r0_val
+        self.bri = interp_r_val
+        self.bzi = interp_z_val
+        self.pa = pa_val
+        self.z = zz_val
+        self.r = rr_val
+        self.zsep = zsep_val
+        self.ring = magnet_val
 
 
-def ring_calculation(R=20, L=50, dR=2, plt_on=False, ax=None):
+def ring_calculation(
+    R: float = 20, L: float = 50, dR: float = 2, plt_on: bool = False, ax: mpl.axes.Axes = None
+) -> tuple[
+    list[float],
+    RegularGridInterpolator,
+    RegularGridInterpolator,
+    list[float],
+    np.ndarray,
+    np.ndarray,
+    float,
+    magpy.magnet.CylinderSegment,
+]:
     """calculate the field and field line length(s)
     return r0, interp_r, interp_z, pa, zz, rr, zsep, magnet"""
 
     # generate ring magnet (same as two cylinders, see notebook)
-    magnet = magpy.magnet.CylinderSegment(
+    magnet: magpy.magnet.CylinderSegment = magpy.magnet.CylinderSegment(
         magnetization=(0, 0, strength),
         dimension=(R, R + dR, L, 0, 360),
         position=(0, 0, 0),
     )
 
     # max. plot/integration region
-    rmax = 1.1 * R
-    zmax = 0.5 * L + dR + 0.5 * R  # should be bigger than the separatrix!!!
+    rmax: float = 1.1 * R
+    zmax: float = 0.5 * L + dR + 0.5 * R  # should be bigger than the separatrix!!!
 
     # pre-compute and plot field of thin_cylinder (faster)
 
     # create grid
-    tr = np.linspace(0, rmax, nres)
-    tz = np.linspace(0, zmax, nres)
-    grid = np.array([[(rh, 0, zh) for zh in tz] for rh in tr])
+    tr: np.ndarray = np.linspace(0, rmax, nres)
+    tz: np.ndarray = np.linspace(0, zmax, nres)
+    grid: np.ndarray = np.array([[(rh, 0, zh) for zh in tz] for rh in tr])
 
     # compute and plot field of thin_cylinder
-    B = magpy.getB(magnet, grid)
+    B: np.ndarray = magpy.getB(magnet, grid)
 
-    z = grid[:, :, 2]  # r,z from grid
-    r = grid[:, :, 0]  # r,z from grid
-    Bz = np.ascontiguousarray(B[:, :, 2])  # r,z from grid
-    Br = np.ascontiguousarray(B[:, :, 0])  # r,z from grid
+    z_grid: np.ndarray = grid[:, :, 2]  # r,z from grid
+    r_grid: np.ndarray = grid[:, :, 0]  # r,z from grid
+    Bz_grid: np.ndarray = np.ascontiguousarray(B[:, :, 2])  # r,z from grid
+    Br_grid: np.ndarray = np.ascontiguousarray(B[:, :, 0])  # r,z from grid
 
-    end_index, zsep = find_separatrix(z, Bz)
-    if end_index == nres:
+    end_index_val, zsep_val = find_separatrix(z_grid, Bz_grid)
+    if end_index_val == nres:
         print("!!! domain too small !!!")
     # zmax = np.ceil(zsep+1)
 

--- a/test_defs.py
+++ b/test_defs.py
@@ -8,47 +8,50 @@ from defs import (
     parallelism, active_volume, add_lengths_to_df # Import necessary items from defs
 )
 from pandas.testing import assert_frame_equal # For DataFrame comparison
+from pytest_mock import MockerFixture # For mocker type hint
 
-def test_find_separatrix_found():
-    z = np.array([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
-    Bz = np.array([[-1, -1, -0.5, 0.1, 0.2, 0.3], [-1, -1, -0.5, 0.1, 0.2, 0.3]])
-    expected_index = 3
-    expected_zsep = 3.0 # z value at z[1, expected_index]
+def test_find_separatrix_found() -> None:
+    z: np.ndarray = np.array([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
+    Bz: np.ndarray = np.array([[-1, -1, -0.5, 0.1, 0.2, 0.3], [-1, -1, -0.5, 0.1, 0.2, 0.3]])
+    expected_index: int = 3
+    expected_zsep: float = 3.0 # z value at z[1, expected_index]
     index, zsep = find_separatrix(z, Bz)
     assert index == expected_index
     assert zsep == expected_zsep
 
-def test_find_separatrix_not_found():
-    z = np.array([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
-    Bz = np.array([[-1, -1, -0.5, -0.1, -0.2, -0.3], [-1, -1, -0.5, -0.1, -0.2, -0.3]])
+def test_find_separatrix_not_found() -> None:
+    z: np.ndarray = np.array([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
+    Bz: np.ndarray = np.array([[-1, -1, -0.5, -0.1, -0.2, -0.3], [-1, -1, -0.5, -0.1, -0.2, -0.3]])
     # nres is imported from defs
-    expected_index = nres # Accessing global nres from defs.py
-    expected_zsep = z[1, -1] # 5.0
+    expected_index: int = nres # Accessing global nres from defs.py
+    expected_zsep: float = z[1, -1] # 5.0
     index, zsep = find_separatrix(z, Bz)
     assert index == expected_index
     assert zsep == expected_zsep
 
-def test_find_separatrix_at_beginning():
-    z = np.array([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
-    Bz = np.array([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]])
-    expected_index = 0
-    expected_zsep = 0.0 # z value at z[1, expected_index]
+def test_find_separatrix_at_beginning() -> None:
+    z: np.ndarray = np.array([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
+    Bz: np.ndarray = np.array([[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]])
+    expected_index: int = 0
+    expected_zsep: float = 0.0 # z value at z[1, expected_index]
     index, zsep = find_separatrix(z, Bz)
     assert index == expected_index
     assert zsep == expected_zsep
 
-def test_find_separatrix_at_end():
-    z = np.array([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
-    Bz = np.array([[-1, -1, -0.5, -0.1, -0.2, 0.3], [-1, -1, -0.5, -0.1, -0.2, 0.3]])
-    expected_index = 5
-    expected_zsep = 5.0 # z value at z[1, expected_index]
+def test_find_separatrix_at_end() -> None:
+    z: np.ndarray = np.array([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
+    Bz: np.ndarray = np.array([[-1, -1, -0.5, -0.1, -0.2, 0.3], [-1, -1, -0.5, -0.1, -0.2, 0.3]])
+    expected_index: int = 5
+    expected_zsep: float = 5.0 # z value at z[1, expected_index]
     index, zsep = find_separatrix(z, Bz)
     assert index == expected_index
     assert zsep == expected_zsep
 
 # Tests for ring_calculation
-def test_ring_calculation_basic_run_and_types():
-    R, L, dR = 20, 50, 2
+def test_ring_calculation_basic_run_and_types() -> None:
+    R: float = 20.0
+    L: float = 50.0
+    dR: float = 2.0
     r0, interp_r, interp_z, pa, zz, rr, zsep, magnet = ring_calculation(R, L, dR, plt_on=False)
 
     assert isinstance(r0, list)
@@ -72,8 +75,10 @@ def test_ring_calculation_basic_run_and_types():
     assert zsep is not None
     assert magnet is not None
 
-def test_ring_calculation_array_shapes():
-    R, L, dR = 20, 50, 2
+def test_ring_calculation_array_shapes() -> None:
+    R: float = 20.0
+    L: float = 50.0
+    dR: float = 2.0
     r0, _, _, pa, zz, rr, _, _ = ring_calculation(R, L, dR) # plt_on defaults to False
 
     assert zz.ndim == 1
@@ -83,33 +88,41 @@ def test_ring_calculation_array_shapes():
     assert len(r0) == nlines + 1 # nlines is from defs.py
     assert len(pa) == 4
 
-def test_ring_calculation_r0_content():
-    R, L, dR = 20, 50, 2
+def test_ring_calculation_r0_content() -> None:
+    R: float = 20.0
+    L: float = 50.0
+    dR: float = 2.0
     r0, _, _, _, _, rr, _, _ = ring_calculation(R, L, dR)
-    assert r0[0] == rr[1] 
-    min_rr_for_r0 = rr[1] 
-    max_rr_for_r0 = rr[-2] 
+    assert r0[0] == rr[1]
+    min_rr_for_r0: float = rr[1]
+    max_rr_for_r0: float = rr[-2]
     if len(r0) > 1:
         assert all(min_rr_for_r0 <= x <= max_rr_for_r0 for x in r0[1:])
 
-def test_ring_calculation_zsep_plausibility():
-    R, L, dR = 20, 50, 2
+def test_ring_calculation_zsep_plausibility() -> None:
+    R: float = 20.0
+    L: float = 50.0
+    dR: float = 2.0
     _, _, _, _, _, _, zsep, _ = ring_calculation(R, L, dR)
     assert zsep > 0
-    zmax_calc = 0.5 * L + dR + 0.5 * R 
-    assert zsep <= zmax_calc 
+    zmax_calc: float = 0.5 * L + dR + 0.5 * R
+    assert zsep <= zmax_calc
 
-def test_ring_calculation_plot_on_true(mocker): 
-    R, L, dR = 20, 50, 2
+def test_ring_calculation_plot_on_true(mocker: MockerFixture) -> None:
+    R: float = 20.0
+    L: float = 50.0
+    dR: float = 2.0
     mock_ax = mocker.Mock()
     ring_calculation(R, L, dR, plt_on=True, ax=mock_ax)
     mock_ax.streamplot.assert_called_once()
     mock_ax.add_collection.assert_called_once()
 
 # Tests for Ring class
-def test_ring_instantiation_and_attributes():
-    R_val, L_val, dR_val = 25, 55, 3
-    ring_instance = Ring(R=R_val, L=L_val, dR=dR_val, plt_on=False)
+def test_ring_instantiation_and_attributes() -> None:
+    R_val: float = 25.0
+    L_val: float = 55.0
+    dR_val: float = 3.0
+    ring_instance: Ring = Ring(R=R_val, L=L_val, dR=dR_val, plt_on=False)
 
     assert ring_instance.R == R_val
     assert ring_instance.L == L_val
@@ -124,100 +137,129 @@ def test_ring_instantiation_and_attributes():
     #     assert all(isinstance(x, float) for x in ring_instance.pa)
     assert isinstance(ring_instance.z, np.ndarray)
     assert isinstance(ring_instance.r, np.ndarray)
-    assert isinstance(ring_instance.zsep, float) 
-    assert isinstance(ring_instance.ring, CylinderSegment) 
-    assert len(ring_instance.r0) == nlines + 1 
+    assert isinstance(ring_instance.zsep, float)
+    assert isinstance(ring_instance.ring, CylinderSegment)
+    assert len(ring_instance.r0) == nlines + 1
     assert ring_instance.z.ndim == 1
     assert ring_instance.z.shape[0] == nres
     assert ring_instance.r.ndim == 1
     assert ring_instance.r.shape[0] == nres
 
-# def test_ring_plt_on_ax_passing(mocker):
-#     R_val, L_val, dR_val = 20, 50, 2
-#     mock_ax_object = mocker.Mock()
-#     mocked_ring_calc = mocker.patch('defs.ring_calculation')
-#     dummy_r0 = [1.0] * (nlines + 1) 
-#     dummy_interp = mocker.Mock(spec=RegularGridInterpolator)
-#     dummy_interp.side_effect = lambda x: np.zeros((x.shape[0],1)) 
-#     dummy_pa = [0.1, 0.2, 0.3, 0.4]
-#     dummy_zz = np.linspace(-10, 10, nres) 
-#     dummy_rr = np.linspace(0, 5, nres)   
-#     dummy_zsep = 5.0
-#     dummy_magnet = mocker.Mock(spec=CylinderSegment)
-#     mocked_ring_calc.return_value = (dummy_r0, dummy_interp, dummy_interp, dummy_pa, dummy_zz, dummy_rr, dummy_zsep, dummy_magnet)
-#     Ring(R=R_val, L=L_val, dR=dR_val, plt_on=True, ax=mock_ax_object)
-#     mocked_ring_calc.assert_called_once_with(
-#         R=R_val, L=L_val, dR=dR_val, 
-#         plt_on=True, ax=mock_ax_object,
-#         param_dict=None, filename=None, Bz0=None, curr=None)
+# def test_ring_plt_on_ax_passing(mocker: MockerFixture) -> None:
+# R_val, L_val, dR_val = 20, 50, 2
+# mock_ax_object = mocker.Mock()
+# mocked_ring_calc = mocker.patch('defs.ring_calculation')
+# dummy_r0 = [1.0] * (nlines + 1)
+# dummy_interp = mocker.Mock(spec=RegularGridInterpolator)
+# dummy_interp.side_effect = lambda x: np.zeros((x.shape[0],1))
+# dummy_pa = [0.1, 0.2, 0.3, 0.4]
+# dummy_zz = np.linspace(-10, 10, nres)
+# dummy_rr = np.linspace(0, 5, nres)
+# dummy_zsep = 5.0
+# dummy_magnet = mocker.Mock(spec=CylinderSegment)
+# mocked_ring_calc.return_value = (dummy_r0, dummy_interp, dummy_interp, dummy_pa, dummy_zz, dummy_rr, dummy_zsep, dummy_magnet)
+# Ring(R=R_val, L=L_val, dR=dR_val, plt_on=True, ax=mock_ax_object)
+# mocked_ring_calc.assert_called_once_with(
+# R=R_val, L=L_val, dR=dR_val,
+# plt_on=True, ax=mock_ax_object,
+# param_dict=None, filename=None, Bz0=None, curr=None)
 
 # Tests for parallelism function
-def test_parallelism_axial_field(mocker):
-    zz = np.array([0, 1, 2, 3]); rr = np.array([0, 0.5, 1]); R_val, L_val, p_val = 1, 3, 1
-    mock_b_interp_r = mocker.Mock(return_value=0.0); mock_b_interp_z = mocker.Mock(return_value=1.0)
+def test_parallelism_axial_field(mocker: MockerFixture) -> None:
+    zz: np.ndarray = np.array([0, 1, 2, 3])
+    rr: np.ndarray = np.array([0, 0.5, 1])
+    R_val: float = 1.0
+    L_val: float = 3.0
+    p_val: float = 1.0
+    mock_b_interp_r = mocker.Mock(return_value=0.0)
+    mock_b_interp_z = mocker.Mock(return_value=1.0)
     assert np.isclose(parallelism(zz, rr, mock_b_interp_z, mock_b_interp_r, R_val, L_val, p_val), 0.0)
 
-def test_parallelism_radial_field(mocker):
-    zz = np.array([0, 1, 2, 3]); rr = np.array([0, 0.5, 1]); R_val, L_val, p_val = 1, 3, 1
-    mock_b_interp_r = mocker.Mock(return_value=1.0); mock_b_interp_z = mocker.Mock(return_value=0.0)
+def test_parallelism_radial_field(mocker: MockerFixture) -> None:
+    zz: np.ndarray = np.array([0, 1, 2, 3])
+    rr: np.ndarray = np.array([0, 0.5, 1])
+    R_val: float = 1.0
+    L_val: float = 3.0
+    p_val: float = 1.0
+    mock_b_interp_r = mocker.Mock(return_value=1.0)
+    mock_b_interp_z = mocker.Mock(return_value=0.0)
     assert np.isclose(parallelism(zz, rr, mock_b_interp_z, mock_b_interp_r, R_val, L_val, p_val), np.pi / 2)
 
-def test_parallelism_br_equals_bz(mocker):
-    zz = np.array([0, 1, 2, 3]); rr = np.array([0, 0.5, 1]); R_val, L_val, p_val = 1, 3, 1
-    mock_b_interp_r = mocker.Mock(return_value=1.0); mock_b_interp_z = mocker.Mock(return_value=1.0)
+def test_parallelism_br_equals_bz(mocker: MockerFixture) -> None:
+    zz: np.ndarray = np.array([0, 1, 2, 3])
+    rr: np.ndarray = np.array([0, 0.5, 1])
+    R_val: float = 1.0
+    L_val: float = 3.0
+    p_val: float = 1.0
+    mock_b_interp_r = mocker.Mock(return_value=1.0)
+    mock_b_interp_z = mocker.Mock(return_value=1.0)
     assert np.isclose(parallelism(zz, rr, mock_b_interp_z, mock_b_interp_r, R_val, L_val, p_val), np.pi / 4)
 
-def test_parallelism_zero_field(mocker):
-    zz = np.array([0, 1, 2, 3]); rr = np.array([0, 0.5, 1]); R_val, L_val, p_val = 1, 3, 1
-    mock_b_interp_r = mocker.Mock(return_value=0.0); mock_b_interp_z = mocker.Mock(return_value=0.0)
+def test_parallelism_zero_field(mocker: MockerFixture) -> None:
+    zz: np.ndarray = np.array([0, 1, 2, 3])
+    rr: np.ndarray = np.array([0, 0.5, 1])
+    R_val: float = 1.0
+    L_val: float = 3.0
+    p_val: float = 1.0
+    mock_b_interp_r = mocker.Mock(return_value=0.0)
+    mock_b_interp_z = mocker.Mock(return_value=0.0)
     assert np.isclose(parallelism(zz, rr, mock_b_interp_z, mock_b_interp_r, R_val, L_val, p_val), 0.0)
 
-# def test_parallelism_p_less_than_one(mocker):
+# def test_parallelism_p_less_than_one(mocker: MockerFixture) -> None:
 #     zz=np.array([0,1,2,3,3.5,4]); rr=np.array([0,0.5,1,1.5]); R_val,L_val,p_val=2,4,0.5
 #     mock_b_interp_r=mocker.Mock(return_value=1.0); mock_b_interp_z=mocker.Mock(return_value=1.0)
 #     assert np.isclose(parallelism(zz,rr,mock_b_interp_z,mock_b_interp_r,R_val,L_val,p_val), np.pi/4)
 #     assert mock_b_interp_r.call_count == 3; assert mock_b_interp_z.call_count == 3
 
-# def test_parallelism_empty_rp_zp(mocker):
+# def test_parallelism_empty_rp_zp(mocker: MockerFixture) -> None:
 #     zz=np.array([0,1,2,3]); rr=np.array([0,0.5,1]); R_val,L_val,p_val=0.1,0.1,1
 #     mock_b_interp_r=mocker.Mock(return_value=1.0); mock_b_interp_z=mocker.Mock(return_value=1.0)
 #     assert np.isclose(parallelism(zz,rr,mock_b_interp_z,mock_b_interp_r,R_val,L_val,p_val),0.0)
 #     assert mock_b_interp_r.call_count == 0; assert mock_b_interp_z.call_count == 0
 
-# def test_parallelism_p_zero(mocker):
+# def test_parallelism_p_zero(mocker: MockerFixture) -> None:
 #     zz=np.array([0,1,2,3]); rr=np.array([0,0.5,1]); R_val,L_val,p_val=1,1,0
 #     mock_b_interp_r=mocker.Mock(return_value=1.0); mock_b_interp_z=mocker.Mock(return_value=1.0)
 #     assert np.isclose(parallelism(zz,rr,mock_b_interp_z,mock_b_interp_r,R_val,L_val,p_val),0.0)
 #     assert mock_b_interp_r.call_count == 0; assert mock_b_interp_z.call_count == 0
 
 # # Tests for active_volume function
-# def test_active_volume_simple_no_modification():
+# def test_active_volume_simple_no_modification() -> None:
 #     z=np.array([0,1,2]); r=np.array([1,1,1]); L,R_param=4,1
 #     assert np.isclose(active_volume(z,r,L,R_param),1.0)
 
-# def test_active_volume_simple_varying_r_no_modification():
+# def test_active_volume_simple_varying_r_no_modification() -> None:
 #     z=np.array([0,1,np.sqrt(2)]); r=np.array([0,1,np.sqrt(2)]); L,R_param=4,np.sqrt(2) # z fixed from example
 #     assert np.isclose(active_volume(z,r,L,R_param),0.5)
 
-def test_active_volume_with_modification():
-    z_orig=np.array([0,0.5]); r_orig=np.array([1,1]); L,R_param=4,1
+def test_active_volume_with_modification() -> None:
+    z_orig: np.ndarray = np.array([0,0.5])
+    r_orig: np.ndarray = np.array([1,1])
+    L: float = 4.0
+    R_param: float = 1.0
     assert np.isclose(active_volume(z_orig,r_orig,L,R_param),1.0)
 
-def test_active_volume_edge_short_arrays_no_modification():
-    z=np.array([0,2]); r=np.array([1,1]); L,R_param=4,1
+def test_active_volume_edge_short_arrays_no_modification() -> None:
+    z: np.ndarray = np.array([0,2])
+    r: np.ndarray = np.array([1,1])
+    L: float = 4.0
+    R_param: float = 1.0
     assert np.isclose(active_volume(z,r,L,R_param),1.0)
 
-def test_active_volume_edge_short_arrays_with_modification():
-    z_orig=np.array([0,1]); r_orig=np.array([1,1]); L,R_param=4,1
+def test_active_volume_edge_short_arrays_with_modification() -> None:
+    z_orig: np.ndarray = np.array([0,1])
+    r_orig: np.ndarray = np.array([1,1])
+    L: float = 4.0
+    R_param: float = 1.0
     assert np.isclose(active_volume(z_orig,r_orig,L,R_param),1.0)
 
 # Tests for add_lengths_to_df function
-def test_add_lengths_to_df_basic_norm_one():
-    data = {'length': [10.0, 20.0], 'mr': [0.5, 0.25], 'r0': [1.0, 2.0]}
-    df = pd.DataFrame(data)
-    df_processed = add_lengths_to_df(df.copy(), norm=1)
+def test_add_lengths_to_df_basic_norm_one() -> None:
+    data: dict[str, list[float]] = {'length': [10.0, 20.0], 'mr': [0.5, 0.25], 'r0': [1.0, 2.0]}
+    df: pd.DataFrame = pd.DataFrame(data)
+    df_processed: pd.DataFrame = add_lengths_to_df(df.copy(), norm=1.0)
 
-    expected_cols = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
+    expected_cols: list[str] = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
     assert list(df_processed.columns) == expected_cols
     assert len(df_processed) == 2
 
@@ -235,17 +277,17 @@ def test_add_lengths_to_df_basic_norm_one():
     assert np.isclose(df_processed['r0_l_mr'].iloc[1], 2.0 * 20.0 * np.sqrt(0.25))
     assert np.isclose(df_processed['r0_l_mr_exp_r0'].iloc[1], 2.0 * 20.0 * np.sqrt(0.25) * np.exp(-2.0))
 
-def test_add_lengths_to_df_with_normalization():
-    data = {'length': [10.0, 20.0], 'mr': [0.5, 0.25], 'r0': [1.0, 2.0]}
-    df = pd.DataFrame(data)
-    norm_val = 2.0
-    df_processed = add_lengths_to_df(df.copy(), norm=norm_val)
+def test_add_lengths_to_df_with_normalization() -> None:
+    data: dict[str, list[float]] = {'length': [10.0, 20.0], 'mr': [0.5, 0.25], 'r0': [1.0, 2.0]}
+    df: pd.DataFrame = pd.DataFrame(data)
+    norm_val: float = 2.0
+    df_processed: pd.DataFrame = add_lengths_to_df(df.copy(), norm=norm_val)
 
-    expected_cols = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
+    expected_cols: list[str] = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
     assert list(df_processed.columns) == expected_cols
 
     # Row 0
-    norm_length_0 = 10.0 / norm_val
+    norm_length_0: float = 10.0 / norm_val
     assert np.isclose(df_processed['length'].iloc[0], norm_length_0)
     assert np.isclose(df_processed['l_mr'].iloc[0], norm_length_0 * np.sqrt(0.5))
     assert np.isclose(df_processed['r0_l'].iloc[0], 1.0 * norm_length_0)
@@ -253,20 +295,20 @@ def test_add_lengths_to_df_with_normalization():
     assert np.isclose(df_processed['r0_l_mr_exp_r0'].iloc[0], 1.0 * norm_length_0 * np.sqrt(0.5) * np.exp(-1.0))
 
     # Row 1
-    norm_length_1 = 20.0 / norm_val
+    norm_length_1: float = 20.0 / norm_val
     assert np.isclose(df_processed['length'].iloc[1], norm_length_1)
     assert np.isclose(df_processed['l_mr'].iloc[1], norm_length_1 * np.sqrt(0.25))
     assert np.isclose(df_processed['r0_l'].iloc[1], 2.0 * norm_length_1)
     assert np.isclose(df_processed['r0_l_mr'].iloc[1], 2.0 * norm_length_1 * np.sqrt(0.25))
     assert np.isclose(df_processed['r0_l_mr_exp_r0'].iloc[1], 2.0 * norm_length_1 * np.sqrt(0.25) * np.exp(-2.0))
 
-def test_add_lengths_to_df_empty():
-    df_empty = pd.DataFrame(columns=['length', 'mr', 'r0'])
-    df_processed = add_lengths_to_df(df_empty.copy())
-    expected_cols = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
-    
+def test_add_lengths_to_df_empty() -> None:
+    df_empty: pd.DataFrame = pd.DataFrame(columns=['length', 'mr', 'r0'])
+    df_processed: pd.DataFrame = add_lengths_to_df(df_empty.copy())
+    expected_cols: list[str] = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
+
     # Convert to float type for empty df to match behavior of non-empty df after calculations
-    expected_df = pd.DataFrame(columns=expected_cols).astype(float)
+    expected_df: pd.DataFrame = pd.DataFrame(columns=expected_cols).astype(float)
     # When 'length', 'mr', 'r0' are initially object/empty, new columns may be object too.
     # The function might create float columns. Check for this.
     # If add_lengths_to_df creates float columns from an empty object DF, this is fine.
@@ -278,7 +320,7 @@ def test_add_lengths_to_df_empty():
                     assert df_processed[col].dtype == object or df_processed[col].dtype == float # can be float if processed
             # else: # New columns should be float  # this fails
             #     assert df_processed[col].dtype == float
-    
+
     # Simpler check for columns and length
     assert list(df_processed.columns) == expected_cols
     assert len(df_processed) == 0
@@ -286,12 +328,12 @@ def test_add_lengths_to_df_empty():
     assert_frame_equal(df_processed, pd.DataFrame(columns=expected_cols).astype(df_processed.dtypes.to_dict()), check_dtype=True)
 
 
-def test_add_lengths_to_df_with_nan():
-    data_nan = {'length': [10.0, np.nan], 'mr': [0.5, 0.25], 'r0': [np.nan, 2.0]}
-    df_nan = pd.DataFrame(data_nan)
-    df_processed = add_lengths_to_df(df_nan.copy())
+def test_add_lengths_to_df_with_nan() -> None:
+    data_nan: dict[str, list[float | np.floating | None]] = {'length': [10.0, np.nan], 'mr': [0.5, 0.25], 'r0': [np.nan, 2.0]}
+    df_nan: pd.DataFrame = pd.DataFrame(data_nan)
+    df_processed: pd.DataFrame = add_lengths_to_df(df_nan.copy())
 
-    expected_cols = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
+    expected_cols: list[str] = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
     assert list(df_processed.columns) == expected_cols
 
     # Row 0 (r0 is NaN)
@@ -311,12 +353,12 @@ def test_add_lengths_to_df_with_nan():
     assert np.isclose(df_processed['mr'].iloc[1], 0.25) # Should remain
     assert np.isclose(df_processed['r0'].iloc[1], 2.0) # Should remain
 
-def test_add_lengths_to_df_with_zeros():
-    data_zeros = {'length': [0.0, 20.0], 'mr': [0.0, 0.25], 'r0': [1.0, 0.0]}
-    df_zeros = pd.DataFrame(data_zeros)
-    df_processed = add_lengths_to_df(df_zeros.copy())
+def test_add_lengths_to_df_with_zeros() -> None:
+    data_zeros: dict[str, list[float]] = {'length': [0.0, 20.0], 'mr': [0.0, 0.25], 'r0': [1.0, 0.0]}
+    df_zeros: pd.DataFrame = pd.DataFrame(data_zeros)
+    df_processed: pd.DataFrame = add_lengths_to_df(df_zeros.copy())
 
-    expected_cols = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
+    expected_cols: list[str] = ['length', 'mr', 'r0', 'l_mr', 'r0_l', 'r0_l_mr', 'r0_l_mr_exp_r0']
     assert list(df_processed.columns) == expected_cols
 
     # Row 0 (length is 0, mr is 0)


### PR DESCRIPTION
This change introduces type hints to function arguments, return types, and variables in both `defs.py` and `test_defs.py` to improve code readability and maintainability.